### PR TITLE
Introduce JSONTree abstraction

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,9 +5,9 @@
         "package": "swift-custom-dump",
         "repositoryURL": "https://github.com/pointfreeco/swift-custom-dump",
         "state": {
-          "branch": null,
-          "revision": "1a2947d25d43e295c6f5e83f54696d590620b364",
-          "version": "0.1.3"
+          "branch": "main",
+          "revision": "23801e4e8098509b738860d8e5fd4d97fd465e73",
+          "version": null
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,7 @@ let package = Package(
     targets: [
         .target(
             name: "XCTJSONKit",
-            dependencies: [.product(name: "CustomDump", package: "swift-custom-dump")],
-            linkerSettings: [.linkedFramework("XCTest")]
+            dependencies: [.product(name: "CustomDump", package: "swift-custom-dump")]
         ),
         .testTarget(name: "XCTJSONKitTests", dependencies: [
             .target(name: "XCTJSONKit"),
@@ -25,5 +24,5 @@ let package = Package(
 )
 
 package.dependencies = [
-    .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.1.3"),
+    .package(url: "https://github.com/pointfreeco/swift-custom-dump", .branch("main")),
 ]

--- a/Sources/XCTJSONKit/JSONTree.swift
+++ b/Sources/XCTJSONKit/JSONTree.swift
@@ -1,0 +1,164 @@
+import CoreFoundation
+import CustomDump
+import Foundation
+
+public enum JSONTree: Hashable {
+    case string(String)
+    case number(Double)
+    indirect case object([String: JSONTree])
+    indirect case array([JSONTree])
+    case bool(Bool)
+    case null
+}
+
+extension JSONTree: ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) {
+        self = .string(value)
+    }
+}
+
+extension JSONTree: ExpressibleByIntegerLiteral {
+    public init(integerLiteral value: IntegerLiteralType) {
+        self = .number(Double(value))
+    }
+}
+
+extension JSONTree: ExpressibleByFloatLiteral {
+    public init(floatLiteral value: FloatLiteralType) {
+        self = .number(value)
+    }
+}
+
+extension JSONTree: ExpressibleByDictionaryLiteral {
+    public init(dictionaryLiteral elements: (String, JSONTree)...) {
+        self = .object(Dictionary(elements, uniquingKeysWith: { current, new in new }))
+    }
+}
+
+extension JSONTree: ExpressibleByArrayLiteral {
+    public init(arrayLiteral elements: JSONTree...) {
+        self = .array(elements)
+    }
+}
+
+extension JSONTree: ExpressibleByBooleanLiteral {
+    public init(booleanLiteral value: BooleanLiteralType) {
+        self = .bool(value)
+    }
+}
+
+extension JSONTree: ExpressibleByNilLiteral {
+    public init(nilLiteral: ()) {
+        self = .null
+    }
+}
+
+extension JSONTree: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        do {
+            let data = try JSONSerialization.data(
+                withJSONObject: self.jsonObject,
+                options: [.fragmentsAllowed, .sortedKeys, .withoutEscapingSlashes, .prettyPrinted]
+            )
+            guard let description = String(data: data, encoding: .utf8) else {
+                throw JSON.Error.failedDataToUT8StringConversion(data)
+            }
+            return description
+        } catch {
+            print("Failed to compute debug description for JSONTree. Error: \(error)")
+        }
+        return "<JSONTree: no description>"
+    }
+}
+
+extension JSONTree: CustomDumpRepresentable {
+    public var customDumpValue: Any {
+        jsonObject
+    }
+}
+
+extension JSONSerialization {
+    public enum Error: LocalizedError {
+        case dataToJSONTreeConversionError(Data)
+        case jsonTreeToDataConversionError(JSONTree)
+
+        public var errorDescription: String? {
+            switch self {
+            case .dataToJSONTreeConversionError(let data):
+                return "Invalid data to JSON tree conversion: '\(data)'"
+            case .jsonTreeToDataConversionError(let tree):
+                return "Invalid JSON tree to data conversion: '\(tree)'"
+            }
+        }
+    }
+
+    public class func jsonTree(
+        with data: Data,
+        options opt: JSONSerialization.ReadingOptions = []
+    ) throws -> JSONTree {
+        let jsonObject = try JSONSerialization.jsonObject(with: data, options: opt)
+        guard let tree = JSONTree(jsonObject) else {
+            throw Error.dataToJSONTreeConversionError(data)
+        }
+        return tree
+    }
+
+    public class func data(
+        withJSONTree tree: JSONTree,
+        options opt: JSONSerialization.WritingOptions = []
+    ) throws -> Data {
+        let data = try JSONSerialization.data(withJSONObject: tree.jsonObject, options: opt)
+        guard !data.isEmpty else {
+            throw Error.jsonTreeToDataConversionError(tree)
+        }
+        return data
+    }
+}
+
+private extension JSONTree {
+    init?(_ jsonObject: Any) {
+        switch jsonObject {
+        case let string as String:
+            self = .string(string)
+        case let nsNumber as NSNumber:
+            if nsNumber.isBoolValue {
+                self = .bool(nsNumber.boolValue)
+            } else {
+                self = .number(nsNumber.doubleValue)
+            }
+        case let object as [String: Any]:
+            self = .object(object.compactMapValues(JSONTree.init))
+        case let array as [Any]:
+            self = .array(array.compactMap(JSONTree.init))
+        case _ as NSNull:
+            self = .null
+        default:
+            return nil
+        }
+    }
+
+    var jsonObject: Any {
+        switch self {
+        case .string(let string):
+            return string
+        case .number(let number):
+            return number
+        case .object(let object):
+            return object.mapValues(\.jsonObject)
+        case .array(let array):
+            return array.map(\.jsonObject)
+        case .bool(let bool):
+            return bool
+        case .null:
+            return NSNull()
+        }
+    }
+}
+
+private extension NSNumber {
+    var isBoolValue: Bool {
+        let boolID = CFBooleanGetTypeID() // the type ID of CFBoolean
+        let numID = CFGetTypeID(self) // the type ID of num
+        return numID == boolID
+    }
+}

--- a/Tests/XCTJSONKitTests/JSONTests.swift
+++ b/Tests/XCTJSONKitTests/JSONTests.swift
@@ -4,54 +4,53 @@ import XCTJSONKit
 final class JSONTests: XCTestCase {
     func testBasicInits() throws {
         // strings
-        try assert(jsonObject: "", raw: #""""#)
-        try assert(jsonObject: "hello world", raw: #""hello world""#)
-        try assert(jsonObject: "hello world\nit's me", raw: #""hello world\nit's me""#)
+        try assert(jsonTree: "", raw: #""""#)
+        try assert(jsonTree: "hello world", raw: #""hello world""#)
+        try assert(jsonTree: "hello world\nit's me", raw: #""hello world\nit's me""#)
 
         // numbers
-        try assert(jsonObject: -3, raw: #"-3"#)
-        try assert(jsonObject: 0, raw: #"0"#)
-        try assert(jsonObject: 3, raw: #"3"#)
-        try assert(jsonObject: 3.25, raw: #"3.25"#)
+        try assert(jsonTree: -3, raw: #"-3"#)
+        try assert(jsonTree: 0, raw: #"0"#)
+        try assert(jsonTree: 3, raw: #"3"#)
+        try assert(jsonTree: 3.25, raw: #"3.25"#)
 
         // objects
-        try assert(jsonObject: [:] as [String: AnyHashable], raw: #"{}"#)
-        try assert(jsonObject: ["": ""], raw: #"{"":""}"#)
-        try assert(jsonObject: ["key": "value"], raw: #"{"key":"value"}"#)
-        try assert(jsonObject: ["key": 1], raw: #"{"key":1}"#)
-        try assert(jsonObject: ["key": ["otherKey": "value"]], raw: #"{"key":{"otherKey":"value"}}"#)
-        try assert(jsonObject: ["key": ["value1", "value2"]], raw: #"{"key":["value1","value2"]}"#)
-        try assert(jsonObject: ["key": true], raw: #"{"key":true}"#)
-        try assert(jsonObject: ["key": NSNull()], raw: #"{"key":null}"#)
+        try assert(jsonTree: [:], raw: #"{}"#)
+        try assert(jsonTree: ["": ""], raw: #"{"":""}"#)
+        try assert(jsonTree: ["key": "value"], raw: #"{"key":"value"}"#)
+        try assert(jsonTree: ["key": 1], raw: #"{"key":1}"#)
+        try assert(jsonTree: ["key": ["otherKey": "value"]], raw: #"{"key":{"otherKey":"value"}}"#)
+        try assert(jsonTree: ["key": ["value1", "value2"]], raw: #"{"key":["value1","value2"]}"#)
+        try assert(jsonTree: ["key": true], raw: #"{"key":true}"#)
+        try assert(jsonTree: ["key": nil], raw: #"{"key":null}"#)
 
         // arrays
-        try assert(jsonObject: [] as [AnyHashable], raw: #"[]"#)
-        try assert(jsonObject: ["", "hello", "world"], raw: #"["","hello","world"]"#)
-        try assert(jsonObject: ["", "hello", "world"], raw: #"["","hello","world"]"#)
-        try assert(jsonObject: [1, 2, 3], raw: #"[1,2,3]"#)
-        try assert(jsonObject: [["key": "value"]], raw: #"[{"key":"value"}]"#)
-        try assert(jsonObject: [[1, 2, 3]], raw: #"[[1,2,3]]"#)
-        try assert(jsonObject: [true, false, true], raw: #"[true,false,true]"#)
-        try assert(jsonObject: [NSNull(), NSNull(), NSNull()].map(AnyHashable.init), raw: #"[null,null,null]"#)
+        try assert(jsonTree: [], raw: #"[]"#)
+        try assert(jsonTree: ["", "hello", "world"], raw: #"["","hello","world"]"#)
+        try assert(jsonTree: ["", "hello", "world"], raw: #"["","hello","world"]"#)
+        try assert(jsonTree: [1, 2, 3], raw: #"[1,2,3]"#)
+        try assert(jsonTree: [["key": "value"]], raw: #"[{"key":"value"}]"#)
+        try assert(jsonTree: [[1, 2, 3]], raw: #"[[1,2,3]]"#)
+        try assert(jsonTree: [true, false, true], raw: #"[true,false,true]"#)
+        try assert(jsonTree: [nil, nil, nil], raw: #"[null,null,null]"#)
 
         // booleans
-        try assert(jsonObject: true, raw: #"true"#)
-        try assert(jsonObject: false, raw: #"false"#)
+        try assert(jsonTree: true, raw: #"true"#)
+        try assert(jsonTree: false, raw: #"false"#)
 
         // null
-        try assert(jsonObject: NSNull(), raw: #"null"#)
-        try assert(json: JSON(Int?.none), jsonObject: NSNull(), raw: #"null"#)
+        try assert(jsonTree: nil, raw: #"null"#)
     }
 
     func testEncodableConversion() throws {
         struct Empty: Encodable {}
-        try assert(json: JSON(of: Empty()), jsonObject: [:] as [String: AnyHashable], raw: #"{}"#)
+        try assert(json: JSON(of: Empty()), jsonTree: [:], raw: #"{}"#)
 
         enum SingleValue: String, Encodable, CaseIterable {
             case one, two, three
         }
-        try assert(json: JSON(of: SingleValue.one), jsonObject: "one", raw: #""one""#)
-        try assert(json: JSON(of: SingleValue.allCases), jsonObject: ["one", "two", "three"], raw: #"["one","two","three"]"#)
+        try assert(json: JSON(of: SingleValue.one), jsonTree: "one", raw: #""one""#)
+        try assert(json: JSON(of: SingleValue.allCases), jsonTree: ["one", "two", "three"], raw: #"["one","two","three"]"#)
 
         struct MultipleValue: Encodable {
             var string: String
@@ -59,7 +58,7 @@ final class JSONTests: XCTestCase {
         }
         try assert(
             json: JSON(of: MultipleValue(string: "a", int: 3)),
-            jsonObject: ["string": "a", "int": 3] as [String: AnyHashable],
+            jsonTree: ["string": "a", "int": 3],
             raw: #"{"int":3,"string":"a"}"#
         )
     }
@@ -79,31 +78,26 @@ final class JSONTests: XCTestCase {
             var int: Int
         }
         try XCTAssertNoDifference(
-            JSON(["string": "a", "int": 3] as [String: AnyHashable]).as(MultipleValue.self),
+            JSON(["string": "a", "int": 3]).as(MultipleValue.self),
             MultipleValue(string: "a", int: 3)
         )
-    }
-
-    func testNull() throws {
-        try assert(json: .null, jsonObject: NSNull(), raw: #"null"#)
-        try assert(json: .null, jsonObject: NSNull(), raw: #"null"#)
     }
 }
 
 private extension JSONTests {
     func assert(
         json: JSON? = nil,
-        jsonObject: AnyHashable,
+        jsonTree: JSONTree,
         raw: String,
         file: StaticString = #filePath,
         line: UInt = #line
     ) throws {
         let suts = try [
-            (json != nil ? "Original JSON" : "init(_ jsonObject:)", json ?? JSON(jsonObject)),
+            (json != nil ? "Original JSON" : "init(_ jsonObject:)", json ?? JSON(jsonTree)),
             ("init(raw:)", JSON(raw: raw))
         ]
         for (origin, sut) in suts {
-            XCTAssertNoDifference(sut.jsonObject, jsonObject, "\(origin) - 'jsonObject' property", file: file, line: line)
+            XCTAssertNoDifference(sut.tree, jsonTree, "\(origin) - 'jsonObject' property", file: file, line: line)
             XCTAssert(sut.data.count > 0, "\(origin) - 'data' is empty", file: file, line: line)
             XCTAssertNoDifference(sut.raw, raw, "\(origin) - 'raw' property", file: file, line: line)
         }

--- a/Tests/XCTJSONKitTests/JSONTreeTests.swift
+++ b/Tests/XCTJSONKitTests/JSONTreeTests.swift
@@ -1,0 +1,48 @@
+import CustomDump
+import XCTJSONKit
+
+final class JSONTreeTests: XCTestCase {
+    func testDebugDescription() {
+        XCTAssertNoDifference(
+            ("foobar" as JSONTree).debugDescription,
+            """
+            "foobar"
+            """
+        )
+        XCTAssertNoDifference(
+            (3 as JSONTree).debugDescription,
+            """
+            3
+            """
+        )
+        XCTAssertNoDifference(
+            (["hello", "world"] as JSONTree).debugDescription,
+            """
+            [
+              "hello",
+              "world"
+            ]
+            """
+        )
+        XCTAssertNoDifference(
+            (["key": "value"] as JSONTree).debugDescription,
+            """
+            {
+              "key" : "value"
+            }
+            """
+        )
+        XCTAssertNoDifference(
+            (true as JSONTree).debugDescription,
+            """
+            true
+            """
+        )
+        XCTAssertNoDifference(
+            (nil as JSONTree).debugDescription,
+            """
+            null
+            """
+        )
+    }
+}

--- a/Tests/XCTJSONKitTests/XCTAssertJSONTests.swift
+++ b/Tests/XCTJSONKitTests/XCTAssertJSONTests.swift
@@ -91,13 +91,13 @@ final class XCTAssertJSONTests: XCTestCase {
         }
         try XCTAssertJSONEncoding(
             MultipleValue(string: "a", int: 3),
-            JSON(["string": "a", "int": 3] as [String: AnyHashable])
+            JSON(["string": "a", "int": 3])
         )
         #if !os(Linux)
         XCTExpectFailure(options: Self.options)
         try XCTAssertJSONEncoding(
             MultipleValue(string: "b", int: 4),
-            JSON(["string": "a", "int": 3] as [String: AnyHashable])
+            JSON(["string": "a", "int": 3])
         )
         #endif
     }
@@ -123,13 +123,13 @@ final class XCTAssertJSONTests: XCTestCase {
             var int: Int
         }
         try XCTAssertJSONDecoding(
-            JSON(["string": "a", "int": 3] as [String: AnyHashable]),
+            JSON(["string": "a", "int": 3]),
             MultipleValue(string: "a", int: 3)
         )
         #if !os(Linux)
         XCTExpectFailure(options: Self.options)
         try XCTAssertJSONDecoding(
-            JSON(["string": "a", "int": 3] as [String: AnyHashable]),
+            JSON(["string": "a", "int": 3]),
             MultipleValue(string: "b", int: 4)
         )
         #endif

--- a/Tests/XCTJSONKitTests/XCTAssertJSONTests.swift
+++ b/Tests/XCTJSONKitTests/XCTAssertJSONTests.swift
@@ -10,6 +10,7 @@ final class XCTAssertJSONTests: XCTestCase {
         }
         try XCTAssertJSONCoding(GoodSingleValue.one)
 
+        #if !os(Linux)
         enum BadSingleValue: String, Codable, CaseIterable, Equatable {
             case one, two, three
 
@@ -19,6 +20,7 @@ final class XCTAssertJSONTests: XCTestCase {
         }
         XCTExpectFailure(options: Self.options)
         try XCTAssertJSONCoding(BadSingleValue.one)
+        #endif
 
         struct GoodMultipleValue: Codable, Equatable {
             var string: String
@@ -26,6 +28,7 @@ final class XCTAssertJSONTests: XCTestCase {
         }
         try XCTAssertJSONCoding(GoodMultipleValue(string: "a", int: 3))
 
+        #if !os(Linux)
         struct BadMultipleValue: Codable, Equatable {
             var string: String
             var int: Int
@@ -40,6 +43,7 @@ final class XCTAssertJSONTests: XCTestCase {
         }
         XCTExpectFailure(options: Self.options)
         try XCTAssertJSONCoding(BadMultipleValue(string: "a", int: 3))
+        #endif
     }
 
     func testXCTAssertJSONCoding_enum() throws {
@@ -48,6 +52,7 @@ final class XCTAssertJSONTests: XCTestCase {
         }
         try XCTAssertJSONCoding(GoodEnum.self)
 
+        #if !os(Linux)
         enum BadEnum: String, Codable, CaseIterable {
             case one, two, three
 
@@ -57,23 +62,28 @@ final class XCTAssertJSONTests: XCTestCase {
         }
         XCTExpectFailure(options: Self.options)
         try XCTAssertJSONCoding(BadEnum.self)
+        #endif
     }
 
     func testXCTAssertJSONEncoding() throws {
         struct Empty: Encodable {}
         try XCTAssertJSONEncoding(Empty(), JSON(raw: #"{}"#))
+        #if !os(Linux)
         XCTExpectFailure(options: Self.options)
         try XCTAssertJSONEncoding(Empty(), JSON(raw: #"[]"#))
+        #endif
 
         enum SingleValue: String, Encodable, CaseIterable {
             case one, two, three
         }
         try XCTAssertJSONEncoding(SingleValue.one, JSON("one"))
         try XCTAssertJSONEncoding(SingleValue.allCases, JSON(["one", "two", "three"]))
+        #if !os(Linux)
         XCTExpectFailure(options: Self.options)
         try XCTAssertJSONEncoding(SingleValue.two, JSON("one"))
         XCTExpectFailure(options: Self.options)
         try XCTAssertJSONEncoding(SingleValue.allCases.reversed(), JSON(["one", "two", "three"]))
+        #endif
 
         struct MultipleValue: Encodable {
             var string: String
@@ -83,11 +93,13 @@ final class XCTAssertJSONTests: XCTestCase {
             MultipleValue(string: "a", int: 3),
             JSON(["string": "a", "int": 3] as [String: AnyHashable])
         )
+        #if !os(Linux)
         XCTExpectFailure(options: Self.options)
         try XCTAssertJSONEncoding(
             MultipleValue(string: "b", int: 4),
             JSON(["string": "a", "int": 3] as [String: AnyHashable])
         )
+        #endif
     }
 
     func testXCTAssertJSONDecoding() throws {
@@ -99,10 +111,12 @@ final class XCTAssertJSONTests: XCTestCase {
         }
         try XCTAssertJSONDecoding(JSON("one"), SingleValue.one)
         try XCTAssertJSONDecoding(JSON(["one", "two", "three"]), SingleValue.allCases)
+        #if !os(Linux)
         XCTExpectFailure(options: Self.options)
         try XCTAssertJSONDecoding(JSON("two"), SingleValue.one)
         XCTExpectFailure(options: Self.options)
         try XCTAssertJSONDecoding(JSON(["two", "one", "three"]), SingleValue.allCases)
+        #endif
 
         struct MultipleValue: Decodable, Equatable {
             var string: String
@@ -112,14 +126,17 @@ final class XCTAssertJSONTests: XCTestCase {
             JSON(["string": "a", "int": 3] as [String: AnyHashable]),
             MultipleValue(string: "a", int: 3)
         )
+        #if !os(Linux)
         XCTExpectFailure(options: Self.options)
         try XCTAssertJSONDecoding(
             JSON(["string": "a", "int": 3] as [String: AnyHashable]),
             MultipleValue(string: "b", int: 4)
         )
+        #endif
     }
 }
 
+#if !os(Linux)
 private extension XCTAssertJSONTests {
     static let options: XCTExpectedFailure.Options = {
         let options = XCTExpectedFailure.Options()
@@ -128,3 +145,4 @@ private extension XCTAssertJSONTests {
         return options
     }()
 }
+#endif


### PR DESCRIPTION
Not only does this improve the ergonomics of JSON formation, but also fixes discrepancies in CI results when running on macOS vs Linux, given the behavioral differences when casting to `AnyHashable` across platforms.