### PR TITLE
Make enum JSON conform to Sendable protocol

### DIFF
--- a/Sources/JSONTesting/JSON.swift
+++ b/Sources/JSONTesting/JSON.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum JSON: Hashable {
+public enum JSON: Hashable, Sendable {
     case string(String)
     case number(Decimal)
     indirect case object([String: JSON])


### PR DESCRIPTION
Trivial PR making `JSON` conform to `Sendable` so it can be used in unit tests where closures are `async`, e.g. in TCA code bases where one is testing a reducer which depends on clients that perform JSON decoding/encoding.