### PR TITLE
Add one convenience method that lets you pass `Data` to `XCTAssertJSONDecoding`

### DIFF
--- a/Sources/JSONTesting/XCTAssertJSON.swift
+++ b/Sources/JSONTesting/XCTAssertJSON.swift
@@ -53,3 +53,15 @@ public func XCTAssertJSONDecoding<T>(
     let decodable = try decodable()
     XCTAssertNoDifference(sut, decodable, message(), file: file, line: line)
 }
+
+public func XCTAssertJSONDecoding<T>(
+    _ jsonData: @autoclosure () throws -> Data,
+    _ decodable: @autoclosure () throws -> T,
+    decoder: JSONDecoder = XCTAssertJSON.configuration.decoder,
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line
+) throws where T: Decodable, T: Equatable {
+    let json = try JSON(data: jsonData())
+    try XCTAssertJSONDecoding(json, decodable(), decoder: decoder, message(), file: file, line: line)
+}

--- a/Tests/JSONTestingTests/XCTAssertJSONTests.swift
+++ b/Tests/JSONTestingTests/XCTAssertJSONTests.swift
@@ -134,6 +134,21 @@ final class XCTAssertJSONTests: XCTestCase {
         )
         #endif
     }
+    
+    func testXCTAssertJSONDecodingPassingData() throws {
+        struct Foo: Codable, Equatable {
+            let bar: Int
+        }
+        let data = try XCTUnwrap(
+            """
+            {
+                "bar": 237
+            }
+            """.data(using: .utf8)
+        )
+        let expected = Foo(bar: 237)
+        try XCTAssertJSONDecoding(data, expected)
+    }
 }
 
 #if !os(Linux)


### PR DESCRIPTION
Saving the developer some keystrokes, having to write `try JSON(data: data)`

It is not apparently clear why this is useful just looking at this PR, but if one is e.g. testing a `TCA` `Reducer` which has a dependency on "Client" doing JSONDecoding, we can get away with writing:

```swift
let store = TestStore(...) {
 $0.userDefaultsClient.saveNewDataForKey = { (data: Data, key: String) in
     XCTAssertJSONDecoding(data, MyCodableModel(value: expectedValue))
 }
}
```

instead of having to do:
```swift
let store = TestStore(...) {
 $0.userDefaultsClient.saveNewDataForKey = { (data: Data, key: String) in
     let json = try JSON(data: data)
     XCTAssertJSONDecoding(json, MyCodableModel(value: expectedValue))
 }
}
```

making the unit test just a liiiitle bit easier to read.